### PR TITLE
feat: UserProvider 기반 로그인 상태 및 토론방 입장 흐름 구현

### DIFF
--- a/src/components/DebateMatchingModal.tsx
+++ b/src/components/DebateMatchingModal.tsx
@@ -1,3 +1,4 @@
+// components/DebateMatchingModal.tsx
 import { useState } from "react";
 import { X } from "lucide-react";
 import {
@@ -15,130 +16,130 @@ import { Debate } from "@/types/debate";
 interface DebateMatchingModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  onStartMatching?: () => void; // 상위와 연동되면 true 설정
 }
 
-export const DebateMatchingModal = ({ open, onOpenChange }: DebateMatchingModalProps) => {
+export const DebateMatchingModal = ({
+                                      open,
+                                      onOpenChange,
+                                      onStartMatching,
+                                    }: DebateMatchingModalProps) => {
   const [selectedCategory, setSelectedCategory] = useState<number | null>(null);
-  const [isMatching, setIsMatching] = useState(false);
-  const [showJoinModal, setShowJoinModal] = useState(false);
+  const [status, setStatus] = useState<'idle' | 'loading' | 'matched'>('idle');
   const [matchedDebate, setMatchedDebate] = useState<Debate | null>(null);
+  const [showJoinModal, setShowJoinModal] = useState(false);
 
-  const handleStartMatching = () => {
-    if (selectedCategory) {
-      setIsMatching(true);
-      onOpenChange(false); // 모달 즉시 닫기
-      
-      // 1초 딜레이 후 토론방 입장 모달 표시
-      setTimeout(() => {
-        const category = debateCategories.find(cat => cat.id === selectedCategory);
-        const mockDebate: Debate = {
-          id: Math.random().toString(),
-          title: `${category?.name} 관련 실시간 토론`,
-          description: `${category?.description}에 대한 다양한 의견을 나누는 토론입니다.`,
-          category: category?.name || "일반",
-          icon: getCategoryIcon(selectedCategory),
-          type: "quick",
-          status: "waiting",
-          participants: { current: 2, max: 6 },
-          audience: { current: 8, max: 50 },
-          duration: 3
-        };
-        
-        setMatchedDebate(mockDebate);
-        setIsMatching(false);
-        setShowJoinModal(true);
-      }, 1000);
-    }
+  const handleStartMatching = async () => {
+    if (!selectedCategory) return;
+
+    // 상위 컴포넌트와 연동
+    onStartMatching?.();
+    setStatus('loading');
+    onOpenChange(false);
+
+    // UX: 매칭 대기 연출
+    await new Promise((r) => setTimeout(r, 1500));
+
+    const category = debateCategories.find((c) => c.id === selectedCategory);
+    const mockDebate: Debate = {
+      id: crypto.randomUUID(),
+      title: `${category?.name} 관련 실시간 토론`,
+      description: `${category?.description}에 대한 다양한 의견을 나누는 토론입니다.`,
+      category: category?.name || '일반',
+      icon: getCategoryIcon(selectedCategory),
+      type: 'quick',
+      status: 'waiting',
+      participants: { current: 2, max: 6 },
+      audience: { current: 8, max: 50 },
+      duration: 3,
+    };
+
+    setMatchedDebate(mockDebate);
+    setStatus('matched');
+    setShowJoinModal(true);
   };
 
   return (
-    <>
-      <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="sm:max-w-[500px] max-w-[320px] p-0 gap-0 border-4 border-quick-debate rounded-xl bg-background max-h-[80vh] overflow-y-auto fixed left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2">
-        <div className="relative p-6 sm:p-10">
-          {/* Close button */}
-          <button
-            onClick={() => onOpenChange(false)}
-            className="absolute top-4 right-5 w-5 h-5 sm:w-6 sm:h-6 flex items-center justify-center text-muted-foreground hover:text-foreground transition-colors border-2 border-muted bg-background"
-          >
-            <X size={16} />
-          </button>
+      <>
+        {/* Step 1: 카테고리 선택 모달 */}
+        <Dialog open={open} onOpenChange={onOpenChange}>
+          <DialogContent className="max-w-[500px] border-4 border-quick-debate rounded-xl p-0">
+            <div className="relative p-6 sm:p-10">
+              <button
+                  onClick={() => onOpenChange(false)}
+                  className="absolute top-4 right-5 text-muted-foreground hover:text-foreground border-2 border-muted bg-background"
+              >
+                <X size={16} />
+              </button>
 
-          <DialogHeader className="text-center mb-6 sm:mb-8">
-            <DialogTitle className="text-xl sm:text-3xl font-bold text-foreground mb-2">
-              토론 매칭 시작
-            </DialogTitle>
-            <p className="text-sm sm:text-base text-muted-foreground">
-              어떤 주제로 토론하고 싶으신가요?
-            </p>
-          </DialogHeader>
+              <DialogHeader className="text-center mb-6">
+                <DialogTitle className="text-2xl font-bold">토론 매칭 시작</DialogTitle>
+                <p className="text-sm text-muted-foreground">
+                  관심 카테고리를 선택해주세요
+                  <br />
+                  <span className="text-xs text-foreground">
+                  어떤 주제로 토론하고 싶으신가요?
+                </span>
+                </p>
+              </DialogHeader>
 
-          <div className="mb-6 sm:mb-8">
-            <label className="block text-sm sm:text-base font-bold text-foreground mb-3 sm:mb-4">
-              관심 카테고리를 선택해주세요
-            </label>
-            
-            <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 sm:gap-3">
-              {debateCategories.map((category) => (
-                <button
-                  key={category.id}
-                  onClick={() => setSelectedCategory(category.id)}
-                  className={`
-                    p-3 sm:p-4 border-2 rounded text-center cursor-pointer transition-all duration-200
-                    ${selectedCategory === category.id 
-                      ? 'border-quick-debate bg-blue-50 text-primary' 
-                      : 'border-border bg-background hover:border-quick-debate'
-                    }
-                  `}
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
+                {debateCategories.map((cat) => (
+                    <button
+                        key={cat.id}
+                        onClick={() => setSelectedCategory(cat.id)}
+                        className={`p-3 border-2 rounded transition-all ${
+                            selectedCategory === cat.id
+                                ? 'border-quick-debate bg-blue-50 text-primary'
+                                : 'border-border hover:border-quick-debate'
+                        }`}
+                    >
+                      <div className="text-sm mb-1">{getCategoryIcon(cat.id)}</div>
+                      <div className="text-xs font-bold">{cat.name}</div>
+                    </button>
+                ))}
+              </div>
+
+              <div className="flex gap-3">
+                <Button
+                    className="w-full bg-quick-debate text-white"
+                    disabled={!selectedCategory}
+                    onClick={handleStartMatching}
                 >
-                  <div className="text-sm sm:text-base mb-1 sm:mb-2">
-                    {getCategoryIcon(category.id)}
-                  </div>
-                  <div className="text-xs sm:text-sm font-bold text-foreground leading-tight">
-                    {category.name}
-                  </div>
-                </button>
-              ))}
+                  매칭 시작
+                </Button>
+                <Button
+                    variant="outline"
+                    className="w-full"
+                    onClick={() => onOpenChange(false)}
+                >
+                  취소
+                </Button>
+              </div>
             </div>
-          </div>
+          </DialogContent>
+        </Dialog>
 
-          <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center">
-            <Button
-              onClick={handleStartMatching}
-              disabled={!selectedCategory}
-              className="w-full sm:w-auto bg-quick-debate hover:bg-quick-debate/90 text-white font-bold px-6 sm:px-8 py-3 text-sm sm:text-base"
-            >
-              매칭 시작
-            </Button>
-            <Button
-              variant="outline"
-              onClick={() => onOpenChange(false)}
-              className="w-full sm:w-auto font-bold px-6 sm:px-8 py-3 text-sm sm:text-base order-first sm:order-last"
-            >
-              취소
-            </Button>
-          </div>
-        </div>
-      </DialogContent>
-    </Dialog>
+        {/* Step 2: 매칭 중 오버레이 */}
+        {status === 'loading' && (
+            <div className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center">
+              <div className="bg-background rounded-2xl p-8 mx-4 max-w-sm w-full text-center border-4 border-quick-debate">
+                <Progress value={75} className="mb-4" />
+                <h3 className="text-lg font-bold text-foreground">토론방을 찾고 있어요...</h3>
+                <p className="text-sm text-muted-foreground">잠시만 기다려 주세요</p>
+              </div>
+            </div>
+        )}
 
-    {/* 매칭 중 오버레이 */}
-    {isMatching && (
-      <div className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center">
-        <div className="bg-background rounded-2xl p-8 mx-4 max-w-sm w-full text-center border-4 border-quick-debate">
-          <div className="mb-6">
-            <Progress value={75} className="w-full mb-4" />
-            <h3 className="text-lg font-bold text-foreground">토론방을 찾고 있어요</h3>
-          </div>
-        </div>
-      </div>
-    )}
-
-    <JoinDebateModal
-      open={showJoinModal}
-      onOpenChange={setShowJoinModal}
-      debate={matchedDebate}
-    />
-    </>
+        {/* Step 3: 매칭된 토론방 입장 모달 */}
+        <JoinDebateModal
+            open={status === 'matched' && showJoinModal}
+            onOpenChange={(open) => {
+              setShowJoinModal(open);
+              if (!open) setStatus('idle');
+            }}
+            debate={matchedDebate}
+        />
+      </>
   );
 };

--- a/src/components/JoinDebateModal.tsx
+++ b/src/components/JoinDebateModal.tsx
@@ -14,11 +14,20 @@ import { DebateSummaryModal } from "./DebateSummaryModal";
 import { LoginModal } from "./LoginModal";
 import { useAuth } from "@/hooks/useAuth";
 import { useToast } from "@/hooks/use-toast";
+import { generateNickname } from "@/lib/nickname/generator";
+import { adjectives, nouns } from "@/lib/nickname/wordlists";
+import {Input} from "postcss";
 
 interface JoinDebateModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   debate: Debate | null;
+}
+
+/* 닉네임 무작위 생성 기능 */
+function getSafeNickname(): string {
+  const nick = generateNickname(adjectives, nouns, true, 50);
+  return nick ?? getSafeNickname(); // 재귀적으로 안전 닉네임 생성
 }
 
 export const JoinDebateModal = ({ open, onOpenChange, debate }: JoinDebateModalProps) => {
@@ -121,6 +130,19 @@ export const JoinDebateModal = ({ open, onOpenChange, debate }: JoinDebateModalP
                 </Badge>
               </div>
             </div>
+
+{/*            {!isLoggedIn && (
+                <div className="flex flex-col gap-2 mt-4">
+                  <Input
+                      value={nickname}
+                      onChange={(e) => setNickname(e.target.value)}
+                      placeholder="닉네임을 입력하세요"
+                  />
+                  <Button variant="outline" onClick={() => setNickname(getSafeNickname())}>
+                    랜덤 닉네임 생성
+                  </Button>
+                </div>
+            )}*/}
 
             {/* Join Buttons */}
             <div className="flex flex-col gap-3 sm:gap-4">

--- a/src/components/_DebateMatchingModal.tsx
+++ b/src/components/_DebateMatchingModal.tsx
@@ -1,0 +1,144 @@
+import { useState } from "react";
+import { X } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+import { debateCategories, getCategoryIcon } from "@/data/categories";
+import { JoinDebateModal } from "./JoinDebateModal";
+import { Debate } from "@/types/debate";
+
+interface DebateMatchingModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export const DebateMatchingModal = ({ open, onOpenChange }: DebateMatchingModalProps) => {
+  const [selectedCategory, setSelectedCategory] = useState<number | null>(null);
+  const [isMatching, setIsMatching] = useState(false);
+  const [showJoinModal, setShowJoinModal] = useState(false);
+  const [matchedDebate, setMatchedDebate] = useState<Debate | null>(null);
+
+  const handleStartMatching = () => {
+    if (selectedCategory) {
+      setIsMatching(true);
+      onOpenChange(false); // 모달 즉시 닫기
+      
+      // 1초 딜레이 후 토론방 입장 모달 표시
+      setTimeout(() => {
+        const category = debateCategories.find(cat => cat.id === selectedCategory);
+        const mockDebate: Debate = {
+          id: Math.random().toString(),
+          title: `${category?.name} 관련 실시간 토론`,
+          description: `${category?.description}에 대한 다양한 의견을 나누는 토론입니다.`,
+          category: category?.name || "일반",
+          icon: getCategoryIcon(selectedCategory),
+          type: "quick",
+          status: "waiting",
+          participants: { current: 2, max: 6 },
+          audience: { current: 8, max: 50 },
+          duration: 3
+        };
+        
+        setMatchedDebate(mockDebate);
+        setIsMatching(false);
+        setShowJoinModal(true);
+      }, 1000);
+    }
+  };
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="sm:max-w-[500px] max-w-[320px] p-0 gap-0 border-4 border-quick-debate rounded-xl bg-background max-h-[80vh] overflow-y-auto fixed left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2">
+        <div className="relative p-6 sm:p-10">
+          {/* Close button */}
+          <button
+            onClick={() => onOpenChange(false)}
+            className="absolute top-4 right-5 w-5 h-5 sm:w-6 sm:h-6 flex items-center justify-center text-muted-foreground hover:text-foreground transition-colors border-2 border-muted bg-background"
+          >
+            <X size={16} />
+          </button>
+
+          <DialogHeader className="text-center mb-6 sm:mb-8">
+            <DialogTitle className="text-xl sm:text-3xl font-bold text-foreground mb-2">
+              토론 매칭 시작
+            </DialogTitle>
+            <p className="text-sm sm:text-base text-muted-foreground">
+              어떤 주제로 토론하고 싶으신가요?
+            </p>
+          </DialogHeader>
+
+          <div className="mb-6 sm:mb-8">
+            <label className="block text-sm sm:text-base font-bold text-foreground mb-3 sm:mb-4">
+              관심 카테고리를 선택해주세요
+            </label>
+            
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 sm:gap-3">
+              {debateCategories.map((category) => (
+                <button
+                  key={category.id}
+                  onClick={() => setSelectedCategory(category.id)}
+                  className={`
+                    p-3 sm:p-4 border-2 rounded text-center cursor-pointer transition-all duration-200
+                    ${selectedCategory === category.id 
+                      ? 'border-quick-debate bg-blue-50 text-primary' 
+                      : 'border-border bg-background hover:border-quick-debate'
+                    }
+                  `}
+                >
+                  <div className="text-sm sm:text-base mb-1 sm:mb-2">
+                    {getCategoryIcon(category.id)}
+                  </div>
+                  <div className="text-xs sm:text-sm font-bold text-foreground leading-tight">
+                    {category.name}
+                  </div>
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center">
+            <Button
+              onClick={handleStartMatching}
+              disabled={!selectedCategory}
+              className="w-full sm:w-auto bg-quick-debate hover:bg-quick-debate/90 text-white font-bold px-6 sm:px-8 py-3 text-sm sm:text-base"
+            >
+              매칭 시작
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              className="w-full sm:w-auto font-bold px-6 sm:px-8 py-3 text-sm sm:text-base order-first sm:order-last"
+            >
+              취소
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+
+    {/* 매칭 중 오버레이 */}
+    {isMatching && (
+      <div className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center">
+        <div className="bg-background rounded-2xl p-8 mx-4 max-w-sm w-full text-center border-4 border-quick-debate">
+          <div className="mb-6">
+            <Progress value={75} className="w-full mb-4" />
+            <h3 className="text-lg font-bold text-foreground">토론방을 찾고 있어요</h3>
+          </div>
+        </div>
+      </div>
+    )}
+
+    <JoinDebateModal
+      open={showJoinModal}
+      onOpenChange={setShowJoinModal}
+      debate={matchedDebate}
+    />
+    </>
+  );
+};

--- a/src/providers/UserProvider.tsx
+++ b/src/providers/UserProvider.tsx
@@ -10,6 +10,8 @@ interface UserContextType {
   user: User | null;
   login: (user: User) => void;
   logout: () => void;
+  guestNickname: string;
+  setGuestNickname: (nickname: string) => void;
 }
 
 const UserContext = createContext<UserContextType | undefined>(undefined);
@@ -20,6 +22,8 @@ export const UserProvider = ({ children }: { children: React.ReactNode }) => {
     return saved ? JSON.parse(saved) : null;
   });
 
+  const [guestNickname, setGuestNickname] = useState<string>("");
+
   const login = (user: User) => {
     sessionStorage.setItem("user", JSON.stringify(user));
     setUser(user);
@@ -28,10 +32,13 @@ export const UserProvider = ({ children }: { children: React.ReactNode }) => {
   const logout = () => {
     sessionStorage.removeItem("user");
     setUser(null);
+    setGuestNickname(""); // 로그아웃 시 guestNickname도 초기화
   };
 
   return (
-    <UserContext.Provider value={{ user, login, logout }}>
+    <UserContext.Provider
+        value={{ user, login, logout, guestNickname, setGuestNickname }}
+    >
       {children}
     </UserContext.Provider>
   );


### PR DESCRIPTION
- UserProvider 추가 및 sessionStorage 연동으로 사용자 정보 전역 상태 관리
- guestNickname 상태 추가로 비로그인 사용자 닉네임도 전역에서 관리
- 토론방 입장 모달에 닉네임 무작위 생성 함수 정의 (input 영역은 주석 처리 상태)
- 매칭 시작 버튼 클릭 시: 프로그레스 모달 → 입장 모달로 연결되는 흐름 구현